### PR TITLE
Do not clear states for multi-widget checkbox

### DIFF
--- a/src/core/iTextSharp/text/pdf/AcroFields.cs
+++ b/src/core/iTextSharp/text/pdf/AcroFields.cs
@@ -1517,10 +1517,6 @@ namespace iTextSharp.text.pdf {
                         merged.Put(PdfName.AS, vt);
                         widget.Put(PdfName.AS, vt);
                     }
-                    else {
-                        merged.Put(PdfName.AS, PdfName.Off_);
-                        widget.Put(PdfName.AS, PdfName.Off_);
-                    }
                     if (generateAppearances && !saveAppearance) {
                         PdfAppearance app = GetAppearance(merged, display, name);
                         if (normal != null)


### PR DESCRIPTION
A checkbox group can have one name and multiple widgets that are valid to
be set independently on a form. However, when setting such a field passing
different valid values only the last one stays on visually, while the
previous ones get erased.

This fix removes such clearing. To actually clear a particular widget some
other mechanism is required, for example, passing a value to use and
additional flag to indicate it needs to be cleared, rather than set.

I am not an expert in a pdf spec, and so if this is a valid behavior then please disregard the pull request. Otherwise, I can provide a specific pdf file that will demonstrate the case.
