### PR TITLE
Fix to Blank Signature checks

### DIFF
--- a/src/core/iTextSharp/text/pdf/AcroFields.cs
+++ b/src/core/iTextSharp/text/pdf/AcroFields.cs
@@ -2161,8 +2161,8 @@ namespace iTextSharp.text.pdf {
                 PdfString contents = v.GetAsString(PdfName.CONTENTS);
                 if (contents == null)
                     continue;
-                var origBytes = contents.GetOriginalBytes();
-                if (origBytes == null || origBytes[0] == 0)
+                byte[] origBytes = contents.GetOriginalBytes();
+                if (origBytes == null || origBytes.Length == 0 || origBytes[0] == 0)
                     continue;
                 PdfArray ro = v.GetAsArray(PdfName.BYTERANGE);
                 if (ro == null)

--- a/src/core/iTextSharp/text/pdf/AcroFields.cs
+++ b/src/core/iTextSharp/text/pdf/AcroFields.cs
@@ -2161,6 +2161,9 @@ namespace iTextSharp.text.pdf {
                 PdfString contents = v.GetAsString(PdfName.CONTENTS);
                 if (contents == null)
                     continue;
+                var origBytes = contents.GetOriginalBytes();
+                if (origBytes == null || origBytes[0] == 0)
+                    continue;
                 PdfArray ro = v.GetAsArray(PdfName.BYTERANGE);
                 if (ro == null)
                     continue;


### PR DESCRIPTION
If a blank signature is added (deffered), as iTextSharp doesn't check the signature contents, it will always be considered blank.

https://gist.github.com/davydsantos/d0bf9b16f36692016c71ebd259280f0c
