### PR TITLE
Issue in CreateInfoId method

### DIFF
--- a/src/core/iTextSharp/text/pdf/PdfEncryption.cs
+++ b/src/core/iTextSharp/text/pdf/PdfEncryption.cs
@@ -529,7 +529,7 @@ public class PdfEncryption {
 
     public static PdfObject CreateInfoId(byte[] id, bool modified) {
         ByteBuffer buf = new ByteBuffer(90);
-        if(id.Length == 0)
+        if(id == null || id.Length == 0)
             id = CreateDocumentId();
         buf.Append('[').Append('<');
         for (int k = 0; k < id.Length; ++k)


### PR DESCRIPTION
Hi,
I`m having a problem using the method MakeSignature.SignDetached. I managed to locate the problem in virtual public PdfObject GetFileID(bool modified) which is implemented in PdfEncryption.cs.
The method was passing null documentID to the CreateInfoId method. In CreateInfoId the code is :

if(id.Length == 0)
    id = CreateDocumentId();
and when id is null I`m getting null object reference.
So to fix you should check:

if (id == null || id.Length == 0).

To reproduce the issue you should try to sign pdf which is encrypted with certificate.

Best regards,
Jovica
