### PR TITLE
SUP-1395: Add 'SuppressTagging' property to PdfContentByte.

### DIFF
--- a/src/core/iTextSharp/text/pdf/PdfContentByte.cs
+++ b/src/core/iTextSharp/text/pdf/PdfContentByte.cs
@@ -260,12 +260,19 @@ namespace iTextSharp.text.pdf {
         }
 
         /**
+         * [SUP-1395] If set, prevents iText from marking content and creating structure tags for items added to this content stream.
+         * (By default, iText automatically marks content using BDC/EMC operators, and adds a structure tag for the new content
+         * at the end of the page.)
+         */
+        public bool SuppressTagging { get; set; }
+
+        /**
          * Checks if the content needs to be tagged.
          * @return false if no tags need to be added
          */
         public virtual bool IsTagged()
         {
-            return writer != null && writer.IsTagged();
+            return writer != null && writer.IsTagged() && !SuppressTagging;
         }
 
         /**


### PR DESCRIPTION
1. Declare a boolean property `SuppressTagging` on PdfContentByte.
2. Modify the `bool IsTagged()` method to return true only if SuppressTagging is false.

Background:

By default, when new content is added to a `PdfContentByte`, iText wraps it in a Begin/End marked content sequence, and inserts a reference to the new MCID at the end of the page's tagged structure tree.  iText consults the `isTagged()` method to determine if the page content is tagged (and by implication should be updated whenever new content is added.)

An application might prefer to disable this behavior and manage the document structure itself.
This property allows an application to prevent iText from adding any marked content or manipulating the structure tree.  When the `SuppressTagging` property is set, `isTagged()` will return false and prevent iText from trying to add structure tags.
