### PR TITLE
Fixed bug causing infinite loop in Merging PDFs with incomplete Num Tree

### DIFF
--- a/src/core/iTextSharp/text/pdf/PdfCopy.cs
+++ b/src/core/iTextSharp/text/pdf/PdfCopy.cs
@@ -947,6 +947,9 @@ namespace iTextSharp.text.pdf {
             //from end, because some objects can appear on several pages because of MCR (out16.pdf)
             for (int i = numTree.Count - 1; i >= 0; --i) {
                 PdfIndirectReference currNum = numTree[i];
+                if (currNum == null) {
+                    continue;
+                }
                 RefKey numKey = new RefKey(currNum);
                 PdfObject obj = indirectObjects[numKey].objecti;
                 if (obj.IsDictionary()) {

--- a/src/core/iTextSharp/text/pdf/PdfStructTreeController.cs
+++ b/src/core/iTextSharp/text/pdf/PdfStructTreeController.cs
@@ -201,10 +201,11 @@ namespace iTextSharp.text.pdf
                     return ReturnType.FOUND;
                 }
                 if (curNumber < arrayNumber) {
-                    begin += cur;
-                    cur /= 2;
                     if (cur == 0)
-                        cur = 1;
+                        return ReturnType.NOTFOUND;
+                    begin += cur;
+                    if (cur != 1)
+                        cur /= 2;
                     if (cur + begin == pages.Size)
                         return ReturnType.NOTFOUND;
                     continue;


### PR DESCRIPTION
Fixes from itextpdf:

https://github.com/itext/itextpdf/commit/5d55de614c87bc72a6e47b0f24e65369d760d1a1
