### PR TITLE
Add a null check in StandardDecryption.Finish

### DIFF
--- a/src/core/iTextSharp/text/pdf/StandardDecryption.cs
+++ b/src/core/iTextSharp/text/pdf/StandardDecryption.cs
@@ -98,7 +98,7 @@ namespace iTextSharp.text.pdf.crypto {
         }
         
         virtual public byte[] Finish() {
-            if (aes) {
+            if (cipher != null && aes) {
                 return cipher.DoFinal();
             }
             else


### PR DESCRIPTION
There's a possibility for cipher to be null here because in Update, cipher isn't initialized if ivptr isn't 16 bytes.
