### PR TITLE
recognise THead and TFoot in XMLWorker

### DIFF
--- a/src/extras/itextsharp.xmlworker/iTextSharp/tool/xml/html/Tags.cs
+++ b/src/extras/itextsharp.xmlworker/iTextSharp/tool/xml/html/Tags.cs
@@ -77,6 +77,8 @@ namespace iTextSharp.tool.xml.html {
             factory.AddProcessor(HTML.Tag.DIV, defaultpackage + "Div");
             factory.AddProcessor(HTML.Tag.A, defaultpackage + "Anchor");
             factory.AddProcessor(HTML.Tag.TABLE, defaultpackage + "table.Table");
+            factory.AddProcessor(HTML.Tag.THEAD, dummyTagProcessor);
+            factory.AddProcessor(HTML.Tag.TFOOT, dummyTagProcessor);
             factory.AddProcessor(HTML.Tag.TR, defaultpackage + "table.TableRow");
             factory.AddProcessor(HTML.Tag.TD, defaultpackage + "table.TableData");
             factory.AddProcessor(HTML.Tag.TH, defaultpackage + "table.TableData");


### PR DESCRIPTION
this will stop an NoTagProcessorException being thrown when THead or TFoot are used
