### PR TITLE
Support for signature policy and workaround for RSA-SHA256 and RSA-SHA512 signatures

### DIFF
--- a/src/core/iTextSharp/text/pdf/security/CryptoConst.cs
+++ b/src/core/iTextSharp/text/pdf/security/CryptoConst.cs
@@ -1,0 +1,85 @@
+﻿/*
+ * $Id$
+ *
+ * This file is part of the iText (R) project.
+ * Copyright (c) 1998-2016 iText Group NV
+ * Authors: Bruno Lowagie, Paulo Soares, et al.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License version 3
+ * as published by the Free Software Foundation with the addition of the
+ * following permission added to Section 15 as permitted in Section 7(a):
+ * FOR ANY PART OF THE COVERED WORK IN WHICH THE COPYRIGHT IS OWNED BY
+ * ITEXT GROUP. ITEXT GROUP DISCLAIMS THE WARRANTY OF NON INFRINGEMENT
+ * OF THIRD PARTY RIGHTS
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+ * or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program; if not, see http://www.gnu.org/licenses or write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA, 02110-1301 USA, or download the license from the following URL:
+ * http://itextpdf.com/terms-of-use/
+ *
+ * The interactive user interfaces in modified source and object code versions
+ * of this program must display Appropriate Legal Notices, as required under
+ * Section 5 of the GNU Affero General Public License.
+ *
+ * In accordance with Section 7(b) of the GNU Affero General Public License,
+ * a covered work must retain the producer line in every PDF that is created
+ * or manipulated using iText.
+ *
+ * You can be released from the requirements of the license by purchasing
+ * a commercial license. Buying such a license is mandatory as soon as you
+ * develop commercial activities involving the iText software without
+ * disclosing the source code of your own applications.
+ * These activities include: offering paid services to customers as an ASP,
+ * serving PDFs on the fly in a web application, shipping iText with a closed
+ * source product.
+ *
+ * For more information, please contact iText Software Corp. at this
+ * address: sales@itextpdf.com
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace iTextSharp.text.pdf.security
+{
+    class CryptoConst
+    {
+        public const string MS_DEF_PROV = "Microsoft Base Cryptographic Provider v1.0";
+        public const string MS_ENHANCED_PROV = "Microsoft Enhanced Cryptographic Provider v1.0";
+        public const string MS_STRONG_PROV = "Microsoft Strong Cryptographic Provider";
+        public const string MS_DEF_RSA_SIG_PROV = "Microsoft RSA Signature Cryptographic Provider";
+        public const string MS_DEF_RSA_SCHANNEL_PROV = "Microsoft RSA SChannel Cryptographic Provider";
+        public const string MS_DEF_DSS_PROV = "Microsoft Base DSS Cryptographic Provider";
+        public const string MS_DEF_DSS_DH_PROV = "Microsoft Base DSS and Diffie-Hellman Cryptographic Provider";
+        public const string MS_ENH_DSS_DH_PROV = "Microsoft Enhanced DSS and Diffie-Hellman Cryptographic Provider";
+        public const string MS_DEF_DH_SCHANNEL_PROV = "Microsoft DH SChannel Cryptographic Provider";
+        public const string MS_SCARD_PROV = "Microsoft Base Smart Card Crypto Provider";
+        public const string MS_ENH_RSA_AES_PROV = "Microsoft Enhanced RSA and AES Cryptographic Provider";
+
+        public const int PROV_RSA_FULL = 1;
+        public const int PROV_RSA_SIG = 2;
+        public const int PROV_DSS = 3;
+        public const int PROV_FORTEZZA = 4;
+        public const int PROV_MS_EXCHANGE = 5;
+        public const int PROV_SSL = 6;
+        public const int PROV_RSA_SCHANNEL = 12;
+        public const int PROV_DSS_DH = 13;
+        public const int PROV_EC_ECDSA_SIG = 14;
+        public const int PROV_EC_ECNRA_SIG = 15;
+        public const int PROV_EC_ECDSA_FULL = 16;
+        public const int PROV_EC_ECNRA_FULL = 17;
+        public const int PROV_DH_SCHANNEL = 18;
+        public const int PROV_SPYRUS_LYNKS = 20;
+        public const int PROV_RNG = 21;
+        public const int PROV_INTEL_SEC = 22;
+        public const int PROV_REPLACE_OWF = 23;
+        public const int PROV_RSA_AES = 24;
+    }
+}

--- a/src/core/iTextSharp/text/pdf/security/MakeSignature.cs
+++ b/src/core/iTextSharp/text/pdf/security/MakeSignature.cs
@@ -82,7 +82,7 @@ namespace iTextSharp.text.pdf.security {
          * @throws Exception 
          */
         public static void SignDetached(PdfSignatureAppearance sap, IExternalSignature externalSignature, ICollection<X509Certificate> chain, ICollection<ICrlClient> crlList, IOcspClient ocspClient,
-                ITSAClient tsaClient, int estimatedSize, CryptoStandard sigtype) {
+                ITSAClient tsaClient, int estimatedSize, CryptoStandard sigtype, SignaturePolicyInfo spi = null) {
             List<X509Certificate> certa = new List<X509Certificate>(chain);
             ICollection<byte[]> crlBytes = null;
             int i = 0;
@@ -116,7 +116,10 @@ namespace iTextSharp.text.pdf.security {
             sap.PreClose(exc);
 
             String hashAlgorithm = externalSignature.GetHashAlgorithm();
+
             PdfPKCS7 sgn = new PdfPKCS7(null, chain, hashAlgorithm, false);
+            sgn.SignaturePolicyInfo = spi;
+
             IDigest messageDigest = DigestUtilities.GetDigest(hashAlgorithm);
             Stream data = sap.GetRangeStream();
             byte[] hash = DigestAlgorithms.Digest(data, hashAlgorithm);

--- a/src/core/iTextSharp/text/pdf/security/PdfPKCS7.cs
+++ b/src/core/iTextSharp/text/pdf/security/PdfPKCS7.cs
@@ -17,50 +17,51 @@ using Org.BouncyCastle.Ocsp;
 using Org.BouncyCastle.Asn1.Pkcs;
 using Org.BouncyCastle.Asn1.Tsp;
 using Org.BouncyCastle.Utilities;
+using Org.BouncyCastle.Asn1.Esf;
 /*
- * $Id: PdfPKCS7.java 5195 2012-06-18 14:25:30Z blowagie $
- *
- * This file is part of the iText (R) project.
- * Copyright (c) 1998-2016 iText Group NV
- * Authors: Bruno Lowagie, Paulo Soares, et al.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License version 3
- * as published by the Free Software Foundation with the addition of the
- * following permission added to Section 15 as permitted in Section 7(a):
- * FOR ANY PART OF THE COVERED WORK IN WHICH THE COPYRIGHT IS OWNED BY
- * ITEXT GROUP. ITEXT GROUP DISCLAIMS THE WARRANTY OF NON INFRINGEMENT
- * OF THIRD PARTY RIGHTS
- *
- * This program is distributed in the hope that it will be useful, but
- * WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
- * or FITNESS FOR A PARTICULAR PURPOSE.
- * See the GNU Affero General Public License for more details.
- * You should have received a copy of the GNU Affero General Public License
- * along with this program; if not, see http://www.gnu.org/licenses or write to
- * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA, 02110-1301 USA, or download the license from the following URL:
- * http://itextpdf.com/terms-of-use/
- *
- * The interactive user interfaces in modified source and object code versions
- * of this program must display Appropriate Legal Notices, as required under
- * Section 5 of the GNU Affero General Public License.
- *
- * In accordance with Section 7(b) of the GNU Affero General Public License,
- * a covered work must retain the producer line in every PDF that is created
- * or manipulated using iText.
- *
- * You can be released from the requirements of the license by purchasing
- * a commercial license. Buying such a license is mandatory as soon as you
- * develop commercial activities involving the iText software without
- * disclosing the source code of your own applications.
- * These activities include: offering paid services to customers as an ASP,
- * serving PDFs on the fly in a web application, shipping iText with a closed
- * source product.
- *
- * For more information, please contact iText Software Corp. at this
- * address: sales@itextpdf.com
- */
+* $Id: PdfPKCS7.java 5195 2012-06-18 14:25:30Z blowagie $
+*
+* This file is part of the iText (R) project.
+* Copyright (c) 1998-2016 iText Group NV
+* Authors: Bruno Lowagie, Paulo Soares, et al.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License version 3
+* as published by the Free Software Foundation with the addition of the
+* following permission added to Section 15 as permitted in Section 7(a):
+* FOR ANY PART OF THE COVERED WORK IN WHICH THE COPYRIGHT IS OWNED BY
+* ITEXT GROUP. ITEXT GROUP DISCLAIMS THE WARRANTY OF NON INFRINGEMENT
+* OF THIRD PARTY RIGHTS
+*
+* This program is distributed in the hope that it will be useful, but
+* WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+* or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Affero General Public License for more details.
+* You should have received a copy of the GNU Affero General Public License
+* along with this program; if not, see http://www.gnu.org/licenses or write to
+* the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA, 02110-1301 USA, or download the license from the following URL:
+* http://itextpdf.com/terms-of-use/
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License,
+* a covered work must retain the producer line in every PDF that is created
+* or manipulated using iText.
+*
+* You can be released from the requirements of the license by purchasing
+* a commercial license. Buying such a license is mandatory as soon as you
+* develop commercial activities involving the iText software without
+* disclosing the source code of your own applications.
+* These activities include: offering paid services to customers as an ASP,
+* serving PDFs on the fly in a web application, shipping iText with a closed
+* source product.
+*
+* For more information, please contact iText Software Corp. at this
+* address: sales@itextpdf.com
+*/
 namespace iTextSharp.text.pdf.security {
 
     /**
@@ -68,6 +69,21 @@ namespace iTextSharp.text.pdf.security {
      * and verifying a PKCS#7 signature.
      */
     public class PdfPKCS7 {
+
+        private SignaturePolicyInfo _signaturePolicyInfo;
+        
+        public SignaturePolicyInfo SignaturePolicyInfo
+        {
+            get
+            {
+                return _signaturePolicyInfo;
+            }
+
+            set
+            {
+                _signaturePolicyInfo = value;
+            }
+        }
 
         // Constructors for creating new signatures
 
@@ -892,6 +908,45 @@ namespace iTextSharp.text.pdf.security {
                 
                 v.Add(new DerSet(new DerSequence(new DerSequence(new DerSequence(aaV2)))));
                 attribute.Add(new DerSequence(v));
+            }
+
+            /*** Signature Policy Info ***/
+            if (_signaturePolicyInfo != null)
+            {
+                if (string.IsNullOrEmpty(_signaturePolicyInfo.PolicyIdentifier))
+                {
+                    throw new NullReferenceException("Policy identifier can't be null");
+                }
+
+                if (string.IsNullOrEmpty(_signaturePolicyInfo.PolicyHash))
+                {
+                    throw new NullReferenceException("Policy hash can't be null");
+                }
+
+                byte[] hashBytes = Convert.FromBase64String(_signaturePolicyInfo.PolicyHash);
+
+                string algId = string.IsNullOrEmpty(_signaturePolicyInfo.PolicyDigestAlgorithm) ? DigestAlgorithms.GetAllowedDigests("SHA-1") :
+                    DigestAlgorithms.GetAllowedDigests(_signaturePolicyInfo.PolicyDigestAlgorithm);
+
+                if (string.IsNullOrEmpty(algId))
+                {
+                    throw new Exception("Invalid policy hash algorithm");
+                }
+
+                SignaturePolicyIdentifier spi = null;
+                SigPolicyQualifierInfo spqi = null;
+
+                if (!string.IsNullOrEmpty(_signaturePolicyInfo.PolicyUri))
+                {
+                    spqi = new SigPolicyQualifierInfo(PkcsObjectIdentifiers.IdSpqEtsUri, new DerIA5String(_signaturePolicyInfo.PolicyUri));
+                }
+
+                spi = new SignaturePolicyIdentifier(new SignaturePolicyId(new DerObjectIdentifier(_signaturePolicyInfo.PolicyIdentifier.Replace("urn:oid:", "")),
+                    new OtherHashAlgAndValue(new AlgorithmIdentifier(algId), new DerOctetString(hashBytes)), spqi));
+
+                var policyAttribute = new Org.BouncyCastle.Asn1.Cms.Attribute(PkcsObjectIdentifiers.IdAAEtsSigPolicyID, new DerSet(spi));
+
+                attribute.Add(policyAttribute);
             }
 
             return new DerSet(attribute);

--- a/src/core/iTextSharp/text/pdf/security/SignaturePolicyInfo.cs
+++ b/src/core/iTextSharp/text/pdf/security/SignaturePolicyInfo.cs
@@ -1,0 +1,69 @@
+﻿/*
+* $Id: SignaturePolicyInfo.cs 2016-05-25 J. Arturo $
+*
+* This file is part of the iText (R) project.
+* Copyright (c) 1998-2016 iText Group NV
+* Authors: Bruno Lowagie, Paulo Soares, et al.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU Affero General Public License version 3
+* as published by the Free Software Foundation with the addition of the
+* following permission added to Section 15 as permitted in Section 7(a):
+* FOR ANY PART OF THE COVERED WORK IN WHICH THE COPYRIGHT IS OWNED BY
+* ITEXT GROUP. ITEXT GROUP DISCLAIMS THE WARRANTY OF NON INFRINGEMENT
+* OF THIRD PARTY RIGHTS
+*
+* This program is distributed in the hope that it will be useful, but
+* WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+* or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Affero General Public License for more details.
+* You should have received a copy of the GNU Affero General Public License
+* along with this program; if not, see http://www.gnu.org/licenses or write to
+* the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA, 02110-1301 USA, or download the license from the following URL:
+* http://itextpdf.com/terms-of-use/
+*
+* The interactive user interfaces in modified source and object code versions
+* of this program must display Appropriate Legal Notices, as required under
+* Section 5 of the GNU Affero General Public License.
+*
+* In accordance with Section 7(b) of the GNU Affero General Public License,
+* a covered work must retain the producer line in every PDF that is created
+* or manipulated using iText.
+*
+* You can be released from the requirements of the license by purchasing
+* a commercial license. Buying such a license is mandatory as soon as you
+* develop commercial activities involving the iText software without
+* disclosing the source code of your own applications.
+* These activities include: offering paid services to customers as an ASP,
+* serving PDFs on the fly in a web application, shipping iText with a closed
+* source product.
+*
+* For more information, please contact iText Software Corp. at this
+* address: sales@itextpdf.com
+*/
+namespace iTextSharp.text.pdf.security
+{
+    /**
+     * Class that encapsulate the signature policy information
+     * @author J. Arturo
+     * 
+     * Sample:
+     * 
+     *      SignaturePolicyInfo spi = new SignaturePolicyInfo();
+     *      spi.PolicyIdentifier = "2.16.724.1.3.1.1.2.1.9";
+     *      spi.PolicyHash = "G7roucf600+f03r/o0bAOQ6WAs0=";
+     *      spi.PolicyDigestAlgorithm = "SHA-1";
+     *      spi.PolicyUri = "https://sede.060.gob.es/politica_de_firma_anexo_1.pdf";
+     */
+    public class SignaturePolicyInfo
+    {
+        public string PolicyIdentifier { get; set; }
+
+        public string PolicyHash { get; set; }
+
+        public string PolicyDigestAlgorithm { get; set; } 
+
+        public string PolicyUri { get; set; }
+    }
+}

--- a/src/core/iTextSharp/text/pdf/security/X509Certificate2Signature.cs
+++ b/src/core/iTextSharp/text/pdf/security/X509Certificate2Signature.cs
@@ -97,20 +97,18 @@ namespace iTextSharp.text.pdf.security
                 // Modified by J. Arturo
                 // Workaround for SHA-256 and SHA-512
 
-                if (rsa.CspKeyContainerInfo.ProviderName == "Microsoft Strong Cryptographic Provider" ||
-                                rsa.CspKeyContainerInfo.ProviderName == "Microsoft Enhanced Cryptographic Provider v1.0" ||
-                                rsa.CspKeyContainerInfo.ProviderName == "Microsoft Base Cryptographic Provider v1.0")
+                if (rsa.CspKeyContainerInfo.ProviderName == CryptoConst.MS_STRONG_PROV ||
+                     rsa.CspKeyContainerInfo.ProviderName == CryptoConst.MS_ENHANCED_PROV ||
+                     rsa.CspKeyContainerInfo.ProviderName == CryptoConst.MS_DEF_PROV)
                 {
-                    string providerName = "Microsoft Enhanced RSA and AES Cryptographic Provider";
-                    int providerType = 24;
-
                     Type CspKeyContainerInfo_Type = typeof(CspKeyContainerInfo);
 
                     FieldInfo CspKeyContainerInfo_m_parameters = CspKeyContainerInfo_Type.GetField("m_parameters", BindingFlags.NonPublic | BindingFlags.Instance);
                     CspParameters parameters = (CspParameters)CspKeyContainerInfo_m_parameters.GetValue(rsa.CspKeyContainerInfo);
 
-                    var cspparams = new CspParameters(providerType, providerName, rsa.CspKeyContainerInfo.KeyContainerName);
+                    var cspparams = new CspParameters(CryptoConst.PROV_RSA_AES, CryptoConst.MS_ENH_RSA_AES_PROV, rsa.CspKeyContainerInfo.KeyContainerName);
                     cspparams.Flags = parameters.Flags;
+                    cspparams.KeyNumber = parameters.KeyNumber;
 
                     using (var rsaKey = new RSACryptoServiceProvider(cspparams))
                     {

--- a/src/core/iTextSharp/text/pdf/security/X509Certificate2Signature.cs
+++ b/src/core/iTextSharp/text/pdf/security/X509Certificate2Signature.cs
@@ -48,13 +48,16 @@ using System.Collections.Generic;
 using System.Text;
 using System.Security.Cryptography.X509Certificates;
 using System.Security.Cryptography;
+using System.Reflection;
 
-namespace iTextSharp.text.pdf.security {
+namespace iTextSharp.text.pdf.security
+{
     /// <summary>
     /// Creates a signature using a X509Certificate2. It supports smartcards without 
     /// exportable private keys.
     /// </summary>
-    public class X509Certificate2Signature : IExternalSignature {
+    public class X509Certificate2Signature : IExternalSignature
+    {
         /// <summary>
         /// The certificate with the private key
         /// </summary>
@@ -63,7 +66,7 @@ namespace iTextSharp.text.pdf.security {
         private String hashAlgorithm;
         /** The encryption algorithm (obtained from the private key) */
         private String encryptionAlgorithm;
-        
+
         /// <summary>
         /// Creates a signature using a X509Certificate2. It supports smartcards without 
         /// exportable private keys.
@@ -71,7 +74,8 @@ namespace iTextSharp.text.pdf.security {
         /// <param name="certificate">The certificate with the private key</param>
         /// <param name="hashAlgorithm">The hash algorithm for the signature. As the Windows CAPI is used
         /// to do the signature the only hash guaranteed to exist is SHA-1</param>
-        public X509Certificate2Signature(X509Certificate2 certificate, String hashAlgorithm) {
+        public X509Certificate2Signature(X509Certificate2 certificate, String hashAlgorithm)
+        {
             if (!certificate.HasPrivateKey)
                 throw new ArgumentException("No private key.");
             this.certificate = certificate;
@@ -84,12 +88,42 @@ namespace iTextSharp.text.pdf.security {
                 throw new ArgumentException("Unknown encryption algorithm " + certificate.PrivateKey);
         }
 
-        public virtual byte[] Sign(byte[] message) {
-            if (certificate.PrivateKey is RSACryptoServiceProvider) {
+        public virtual byte[] Sign(byte[] message)
+        {
+            if (certificate.PrivateKey is RSACryptoServiceProvider)
+            {                
                 RSACryptoServiceProvider rsa = (RSACryptoServiceProvider)certificate.PrivateKey;
-                return rsa.SignData(message, hashAlgorithm);
+
+                // Modified by J. Arturo
+                // Workaround for SHA-256 and SHA-512
+
+                if (rsa.CspKeyContainerInfo.ProviderName == "Microsoft Strong Cryptographic Provider" ||
+                                rsa.CspKeyContainerInfo.ProviderName == "Microsoft Enhanced Cryptographic Provider v1.0" ||
+                                rsa.CspKeyContainerInfo.ProviderName == "Microsoft Base Cryptographic Provider v1.0")
+                {
+                    string providerName = "Microsoft Enhanced RSA and AES Cryptographic Provider";
+                    int providerType = 24;
+
+                    Type CspKeyContainerInfo_Type = typeof(CspKeyContainerInfo);
+
+                    FieldInfo CspKeyContainerInfo_m_parameters = CspKeyContainerInfo_Type.GetField("m_parameters", BindingFlags.NonPublic | BindingFlags.Instance);
+                    CspParameters parameters = (CspParameters)CspKeyContainerInfo_m_parameters.GetValue(rsa.CspKeyContainerInfo);
+
+                    var cspparams = new CspParameters(providerType, providerName, rsa.CspKeyContainerInfo.KeyContainerName);
+                    cspparams.Flags = parameters.Flags;
+
+                    using (var rsaKey = new RSACryptoServiceProvider(cspparams))
+                    {
+                        return rsaKey.SignData(message, hashAlgorithm);
+                    }
+                }
+                else
+                {
+                    return rsa.SignData(message, hashAlgorithm);
+                }
             }
-            else {
+            else
+            {
                 DSACryptoServiceProvider dsa = (DSACryptoServiceProvider)certificate.PrivateKey;
                 return dsa.SignData(message);
             }
@@ -100,16 +134,18 @@ namespace iTextSharp.text.pdf.security {
          * @return  the hash algorithm (e.g. "SHA-1", "SHA-256,...")
          * @see com.itextpdf.text.pdf.security.ExternalSignature#getHashAlgorithm()
          */
-        public virtual String GetHashAlgorithm() {
+        public virtual String GetHashAlgorithm()
+        {
             return hashAlgorithm;
         }
-        
+
         /**
          * Returns the encryption algorithm used for signing.
          * @return the encryption algorithm ("RSA" or "DSA")
          * @see com.itextpdf.text.pdf.security.ExternalSignature#getEncryptionAlgorithm()
          */
-        public virtual String GetEncryptionAlgorithm() {
+        public virtual String GetEncryptionAlgorithm()
+        {
             return encryptionAlgorithm;
         }
     }

--- a/src/core/itextsharp.csproj
+++ b/src/core/itextsharp.csproj
@@ -960,6 +960,7 @@
     <Compile Include="iTextSharp\text\pdf\RandomAccessFileOrArray.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="iTextSharp\text\pdf\security\SignaturePolicyInfo.cs" />
     <Compile Include="iTextSharp\text\pdf\SequenceList.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/src/core/itextsharp.csproj
+++ b/src/core/itextsharp.csproj
@@ -960,6 +960,7 @@
     <Compile Include="iTextSharp\text\pdf\RandomAccessFileOrArray.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="iTextSharp\text\pdf\security\CryptoConst.cs" />
     <Compile Include="iTextSharp\text\pdf\security\SignaturePolicyInfo.cs" />
     <Compile Include="iTextSharp\text\pdf\SequenceList.cs">
       <SubType>Code</SubType>

--- a/src/core/itextsharp.csproj
+++ b/src/core/itextsharp.csproj
@@ -1,4 +1,5 @@
-﻿<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="14.0">
   <PropertyGroup>
     <ProjectType>Local</ProjectType>
     <ProductVersion>8.0.50727</ProductVersion>
@@ -27,6 +28,8 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <SignAssembly>true</SignAssembly>
+    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
+    <OldToolsVersion>2.0</OldToolsVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <OutputPath>bin\Debug\</OutputPath>

--- a/src/core/itextsharp.sln
+++ b/src/core/itextsharp.sln
@@ -1,5 +1,7 @@
-Microsoft Visual Studio Solution File, Format Version 9.00
-# Visual Studio 2005
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 14
+VisualStudioVersion = 14.0.25123.0
+MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "itextsharp", "itextsharp.csproj", "{84C4FDD9-3ED7-453B-B9DA-B3ED52CB071C}"
 EndProject
 Global


### PR DESCRIPTION
Hi,

This pull request contains these changes:
- Added support for signature policy.
- Workaround on X509Certificate2Signature class for RSA-SHA256 and RSA-SHA512 signatures.

I hope it will be useful,

regards.
