### PR TITLE
Fix portation error in PdfDictionary

### DIFF
--- a/src/core/iTextSharp/text/pdf/PdfDictionary.cs
+++ b/src/core/iTextSharp/text/pdf/PdfDictionary.cs
@@ -221,6 +221,9 @@ namespace iTextSharp.text.pdf {
          * @return        the previous </CODE>PdfObject</CODE> corresponding with the <VAR>key</VAR>
          */
         virtual public PdfObject Get(PdfName key) {
+            if (key == null)
+              return null;
+
             PdfObject obj;
             if (hashMap.TryGetValue(key, out obj))
                 return obj;
@@ -320,7 +323,7 @@ namespace iTextSharp.text.pdf {
         }
     
         virtual public bool Contains(PdfName key) {
-            return hashMap.ContainsKey(key);
+            return key != null && hashMap.ContainsKey(key);
         }
 
         public virtual Dictionary<PdfName,PdfObject>.Enumerator GetEnumerator() {

--- a/src/extras/itextsharp.tests/iTextSharp/text/pdf/PdfDictionaryTest.cs
+++ b/src/extras/itextsharp.tests/iTextSharp/text/pdf/PdfDictionaryTest.cs
@@ -1,0 +1,71 @@
+﻿/*
+    This file is part of the iText (R) project.
+    Copyright (c) 1998-2017 iText Group NV
+    Authors: iText Software.
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License version 3
+    as published by the Free Software Foundation with the addition of the
+    following permission added to Section 15 as permitted in Section 7(a):
+    FOR ANY PART OF THE COVERED WORK IN WHICH THE COPYRIGHT IS OWNED BY
+    ITEXT GROUP. ITEXT GROUP DISCLAIMS THE WARRANTY OF NON INFRINGEMENT
+    OF THIRD PARTY RIGHTS
+    
+    This program is distributed in the hope that it will be useful, but
+    WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+    or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU Affero General Public License for more details.
+    You should have received a copy of the GNU Affero General Public License
+    along with this program; if not, see http://www.gnu.org/licenses or write to
+    the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+    Boston, MA, 02110-1301 USA, or download the license from the following URL:
+    http://itextpdf.com/terms-of-use/
+    
+    The interactive user interfaces in modified source and object code versions
+    of this program must display Appropriate Legal Notices, as required under
+    Section 5 of the GNU Affero General Public License.
+    
+    In accordance with Section 7(b) of the GNU Affero General Public License,
+    a covered work must retain the producer line in every PDF that is created
+    or manipulated using iText.
+    
+    You can be released from the requirements of the license by purchasing
+    a commercial license. Buying such a license is mandatory as soon as you
+    develop commercial activities involving the iText software without
+    disclosing the source code of your own applications.
+    These activities include: offering paid services to customers as an ASP,
+    serving PDFs on the fly in a web application, shipping iText with a closed
+    source product.
+    
+    For more information, please contact iText Software Corp. at this
+    address: sales@itextpdf.com
+ */
+using System;
+using iTextSharp.text.pdf;
+using NUnit.Framework;
+
+namespace itextsharp.tests.iTextSharp.text.pdf
+{
+  public class PdfDictionaryTest
+  {
+    [Test]
+    public void PdfDictionaryGetReturnsNullIfKeyIsNull()
+    {
+      var dictionary = new PdfDictionary();
+
+      var value = dictionary.Get (null);
+
+      Assert.IsNull (value);
+    }
+
+    [Test]
+    public void PdfDictionaryContainsReturnsFalseIfKeyIsNull()
+    {
+      var dictionary = new PdfDictionary();
+
+      var contained = dictionary.Contains (null);
+
+      Assert.False (contained);
+    }
+  }
+}

--- a/src/extras/itextsharp.tests/itextsharp.tests(VS2010).csproj
+++ b/src/extras/itextsharp.tests/itextsharp.tests(VS2010).csproj
@@ -91,6 +91,7 @@
     <Compile Include="iTextSharp\text\pdf\AcroFieldsTest.cs" />
     <Compile Include="iTextSharp\text\pdf\BarcodeUnicodeTest.cs" />
     <Compile Include="iTextSharp\text\pdf\BookmarksTest.cs" />
+    <Compile Include="iTextSharp\text\pdf\PdfDictionaryTest.cs" />
     <Compile Include="iTextSharp\text\pdf\PdfEncryptionTest.cs" />
     <Compile Include="iTextSharp\text\pdf\CMapAwareDocumentFontTest.cs" />
     <Compile Include="iTextSharp\text\pdf\cs\DeviceNColorSpaceTest.cs" />


### PR DESCRIPTION
Java HashMap and .net Dictionary have different behaviour for null keys. Java allows null keys in the map, .net throws exceptions as soon as a null key is passed to the Dictionary.

This fix prevents exceptions in methods that don't change the Dictionaries contents, since the Dictionary can never contain a null key. Therefore the Get and Contains were changed to return null/false for null keys.

This fixes a ArgumentNullException we got when we tried to remove invisible layers using the OCGRemover.