### PR TITLE
prevent parsing of star comments in HTML

### DIFF
--- a/src/extras/itextsharp.xmlworker.tests/iTextSharp/tool/xml/BugRunnerTest.cs
+++ b/src/extras/itextsharp.xmlworker.tests/iTextSharp/tool/xml/BugRunnerTest.cs
@@ -65,6 +65,7 @@ namespace itextsharp.xmlworker.tests.iTextSharp.tool.xml {
             list.Add("3353957.html");
             list.Add("ol-test.html");
             list.Add("processing-instructions.html");
+            list.Add("starcomments.html");
 
             Directory.CreateDirectory(TARGET + "bugs/");
         }

--- a/src/extras/itextsharp.xmlworker.tests/itextsharp.xmlworker.tests(VS2010).csproj
+++ b/src/extras/itextsharp.xmlworker.tests/itextsharp.xmlworker.tests(VS2010).csproj
@@ -573,6 +573,7 @@
     <Content Include="resources\bugs\3353957.html" />
     <Content Include="resources\bugs\colored_lists_snippet.html" />
     <Content Include="resources\bugs\ol-test.html" />
+    <Content Include="resources\bugs\starcomments.html" />
     <Content Include="resources\bugs\processing-instructions.html" />
     <Content Include="resources\com\itextpdf\tool\xml\examples\css\background\background_color\cell\background_color_cell01\background_color_cell01.html" />
     <Content Include="resources\com\itextpdf\tool\xml\examples\css\background\background_color\cell\background_color_cell02\background_color_cell02.html" />

--- a/src/extras/itextsharp.xmlworker.tests/itextsharp.xmlworker.tests.csproj
+++ b/src/extras/itextsharp.xmlworker.tests/itextsharp.xmlworker.tests.csproj
@@ -571,6 +571,7 @@
     <Content Include="resources\bugs\3353957.html" />
     <Content Include="resources\bugs\colored_lists_snippet.html" />
     <Content Include="resources\bugs\ol-test.html" />
+    <Content Include="resources\bugs\starcomments.html" />
     <Content Include="resources\bugs\processing-instructions.html" />
     <Content Include="resources\com\itextpdf\tool\xml\examples\css\background\background_color\cell\background_color_cell01\background_color_cell01.html" />
     <Content Include="resources\com\itextpdf\tool\xml\examples\css\background\background_color\cell\background_color_cell02\background_color_cell02.html" />

--- a/src/extras/itextsharp.xmlworker.tests/resources/bugs/starcomments.html
+++ b/src/extras/itextsharp.xmlworker.tests/resources/bugs/starcomments.html
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<html>
+<head>
+</head>
+<body>
+	http://www.example.com/<br/>* hi
+
+    <style>/* Well-formed css comment */</style>
+
+    /<style>* intentionally misformed */</style>
+</body>
+</html>

--- a/src/extras/itextsharp.xmlworker/iTextSharp/tool/xml/parser/state/InsideTagHTMLState.cs
+++ b/src/extras/itextsharp.xmlworker/iTextSharp/tool/xml/parser/state/InsideTagHTMLState.cs
@@ -95,7 +95,7 @@ namespace iTextSharp.tool.xml.parser.state {
             } else if (character == '&') {
                 this.parser.SelectState().SpecialChar();
             } else  {
-                if (character == '*' && this.parser.Memory().LastChar == '/')
+                if (this.parser.CurrentTag() == HTML.Tag.STYLE && character == '*' && this.parser.Memory().LastChar == '/' && parser.Memory().Current().Length > 0)
                 {
                     this.parser.SelectState().StarComment();
                     this.parser.Memory()


### PR DESCRIPTION
change the HTML parser to only parse star comments in style tags and check for buffer space when deleting one character.