### PR TITLE
Fix: Inline style property value for `CJK characters' will be garbled.

### DIFF
--- a/src/extras/itextsharp.xmlworker.tests/iTextSharp/tool/xml/pipeline/CssResolverPipelineTest.cs
+++ b/src/extras/itextsharp.xmlworker.tests/iTextSharp/tool/xml/pipeline/CssResolverPipelineTest.cs
@@ -55,11 +55,11 @@ namespace itextsharp.xmlworker.tests.iTextSharp.tool.xml.pipeline {
         [SetUp]
         virtual public void SetUp() {
             StyleAttrCSSResolver css = new StyleAttrCSSResolver();
-            css.AddCss("dummy { key1: value1; key2: value2 } .aklass { key3: value3;} #dumid { key4: value4}", true);
+            css.AddCss("dummy { key1: value1; key2: value2 } .aklass { key3: value3;} #dumid { key4: value4} .cjk { key5: \"ËÎÌו\", Helvetica ; key6:value6}", true);
             CssResolverPipeline p = new CssResolverPipeline(css, null);
             Tag t = new Tag("dummy");
             t.Attributes["id"] = "dumid";
-            t.Attributes["class"] = "aklass";
+            t.Attributes["class"] = "aklass cjk";
             WorkerContextImpl context = new WorkerContextImpl();
             p.Init(context);
             IPipeline open = p.Open(context, t, null);
@@ -100,6 +100,8 @@ namespace itextsharp.xmlworker.tests.iTextSharp.tool.xml.pipeline {
         [Test]
         virtual public void VerifyCssResolvedClass() {
             Assert.AreEqual("value3", css2["key3"]);
+            Assert.AreEqual("\"ËÎÌו\", Helvetica", css2["key5"]);
+            Assert.AreEqual("value6", css2["key6"]);
         }
 
         /**

--- a/src/extras/itextsharp.xmlworker.tests/iTextSharp/tool/xml/pipeline/CssResolverPipelineTest.cs
+++ b/src/extras/itextsharp.xmlworker.tests/iTextSharp/tool/xml/pipeline/CssResolverPipelineTest.cs
@@ -1,4 +1,4 @@
-/*
+ï»¿/*
     This file is part of the iText (R) project.
     Copyright (c) 1998-2017 iText Group NV
     Authors: iText Software.
@@ -55,7 +55,7 @@ namespace itextsharp.xmlworker.tests.iTextSharp.tool.xml.pipeline {
         [SetUp]
         virtual public void SetUp() {
             StyleAttrCSSResolver css = new StyleAttrCSSResolver();
-            css.AddCss("dummy { key1: value1; key2: value2 } .aklass { key3: value3;} #dumid { key4: value4} .cjk { key5: \"ËÎÌå\", Helvetica ; key6:value6}", true);
+            css.AddCss("dummy { key1: value1; key2: value2 } .aklass { key3: value3;} #dumid { key4: value4} .cjk { key5: \"å®‹ä½“\", Helvetica ; key6:value6}", true);
             CssResolverPipeline p = new CssResolverPipeline(css, null);
             Tag t = new Tag("dummy");
             t.Attributes["id"] = "dumid";
@@ -100,7 +100,7 @@ namespace itextsharp.xmlworker.tests.iTextSharp.tool.xml.pipeline {
         [Test]
         virtual public void VerifyCssResolvedClass() {
             Assert.AreEqual("value3", css2["key3"]);
-            Assert.AreEqual("\"ËÎÌå\", Helvetica", css2["key5"]);
+            Assert.AreEqual("\"å®‹ä½“\", Helvetica", css2["key5"]);
             Assert.AreEqual("value6", css2["key6"]);
         }
 

--- a/src/extras/itextsharp.xmlworker/iTextSharp/tool/xml/css/StyleAttrCSSResolver.cs
+++ b/src/extras/itextsharp.xmlworker/iTextSharp/tool/xml/css/StyleAttrCSSResolver.cs
@@ -439,16 +439,19 @@ namespace iTextSharp.tool.xml.css {
          */
         virtual public void AddCss(String content, bool isPersistent) {
             CssFileProcessor proc = new CssFileProcessor();
-            IFileRetrieve retrieve = new FileRetrieveImpl();
             try {
-                retrieve.ProcessFromStream(new MemoryStream(Encoding.GetEncoding(1252).GetBytes(content)), proc);
+                if (content != null) {
+                    foreach (char item in content) {
+                        proc.Process(item);
+                    }
+                }
+
                 ICssFile css = proc.GetCss();
                 css.IsPersistent(isPersistent);
                 this.cssFiles.Add(css);
             } catch (IOException e) {
                 throw new CssResolverException(e);
             }
-
         }
 
         /**


### PR DESCRIPTION
When parsing the HTML `inline style`, the `content` string argument should not be converted to `Stream`  . because the encoding is explicitly specified as `Encoding.GetEncoding (1252)`, Some `property values` contain `CJK` characters will be garbled, for example, the following` inline style`:
```Css
.cjk {
    font-family: "宋体";
}
```
`font-family` property value `宋体`  will be parsed to `????`, this is wrong;.
