### PR TITLE
Fix NullReferenceException

### DIFF
--- a/src/core/iTextSharp/text/pdf/parser/ImageRenderInfo.cs
+++ b/src/core/iTextSharp/text/pdf/parser/ImageRenderInfo.cs
@@ -74,7 +74,7 @@ namespace iTextSharp.text.pdf.parser {
             this.inlineImageInfo = null;
             this.colorSpaceDictionary = colorSpaceDictionary;
             this.markedContentInfos = new List<MarkedContentInfo>();
-            if (markedContentInfos.Count > 0) { // check for performance purposes, as markedContentInfo.GetEnumerator is a costly operation for some reason
+            if (markedContentInfos != null && markedContentInfos.Count > 0) { // check for performance purposes, as markedContentInfo.GetEnumerator is a costly operation for some reason
                 foreach (MarkedContentInfo m in markedContentInfos) {
                     this.markedContentInfos.Add(m);
                 }
@@ -87,7 +87,7 @@ namespace iTextSharp.text.pdf.parser {
             this.inlineImageInfo = inlineImageInfo;
             this.colorSpaceDictionary = colorSpaceDictionary;
             this.markedContentInfos = new List<MarkedContentInfo>();
-            if (markedContentInfos.Count > 0) { // check for performance purposes, as markedContentInfo.GetEnumerator is a costly operation for some reason
+            if (markedContentInfos != null && markedContentInfos.Count > 0) { // check for performance purposes, as markedContentInfo.GetEnumerator is a costly operation for some reason
                 foreach (MarkedContentInfo m in markedContentInfos) {
                     this.markedContentInfos.Add(m);
                 }


### PR DESCRIPTION
Throws NullRefenceException calling method ImageRenderInfo CreateForXObject(GraphicsState gs, PdfIndirectReference refi, PdfDictionary colorSpaceDictionary) because the last argument is null.