### PR TITLE
Eliminate file handle leaks caused by PdfCotentReaderTool

### DIFF
--- a/src/core/iTextSharp/text/pdf/parser/PdfContentReaderTool.cs
+++ b/src/core/iTextSharp/text/pdf/parser/PdfContentReaderTool.cs
@@ -181,14 +181,13 @@ namespace iTextSharp.text.pdf.parser {
          * @throws IOException
          */
         public static void ListContentStream(string pdfFile, TextWriter outp) {
-            PdfReader reader = new PdfReader(pdfFile);
+            using(PdfReader reader = new PdfReader(pdfFile)){
+                int maxPageNum = reader.NumberOfPages;
 
-            int maxPageNum = reader.NumberOfPages;
-
-            for (int pageNum = 1; pageNum <= maxPageNum; pageNum++){
-                ListContentStreamForPage(reader, pageNum, outp);
+                for (int pageNum = 1; pageNum <= maxPageNum; pageNum++){
+                    ListContentStreamForPage(reader, pageNum, outp);
+                }
             }
-
         }
 
         /**
@@ -200,9 +199,9 @@ namespace iTextSharp.text.pdf.parser {
          * @throws IOException
          */
         public static void ListContentStream(string pdfFile, int pageNum, TextWriter outp) {
-            PdfReader reader = new PdfReader(pdfFile);
-
-            ListContentStreamForPage(reader, pageNum, outp);
+            using (PdfReader reader = new PdfReader(pdfFile)){
+                ListContentStreamForPage(reader, pageNum, outp);
+            }
         }
 
         /**


### PR DESCRIPTION
Noticed these undisposed `PdfReader` objects, as they were leaking file handles in a project I was using this in. Haven't looked too much further for similar issues though... just fixed the ones that were obvious 😃 