### PR TITLE
Commit HF - Addition of WebProxy

### DIFF
--- a/src/core/iTextSharp/text/pdf/security/ITSAClient.cs
+++ b/src/core/iTextSharp/text/pdf/security/ITSAClient.cs
@@ -76,5 +76,11 @@ namespace iTextSharp.text.pdf.security {
          * @throws Exception - TSA request failed
          */
         byte[] GetTimeStampToken(byte[] imprint);
+		
+        /**
+         * Sets the webproxy needed when working behing proxy.
+         * @param proxy WebProxy
+         */
+        void SetProxy(System.Net.WebProxy proxy);							 
     }
 }


### PR DESCRIPTION
Added WebProxy to TSAClientBouncyCastle.
It is required when working behind a proxy server.

Somehow the java version has implemented the proxy but not the .net version.
Also i had a look to the IText 7 Core (at least on the NuGet), also did not have the implementation of proxy in this class.

The proxy will be used when on the webrequest in  GetTSAResponse() method.